### PR TITLE
Use maven bundle plugin correctly

### DIFF
--- a/dynkt-osgi/pom.xml
+++ b/dynkt-osgi/pom.xml
@@ -10,17 +10,11 @@
 	</parent>
 
 	<artifactId>dynkt-jsr223-osgi</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>DynKT (Dynamic Kotlin) OSGi Bundle</name>
 	<description>This is a JSR-223 scripting engine for the language "Kotlin".</description>
 	<url>https://github.com/xafero/dynkt</url>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>		
-	</properties>
 
 	<dependencies>
 		<!-- Script engine -->
@@ -34,56 +28,28 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>unpack-everything</id>
-						<phase>generate-resources</phase>
-						<goals>
-							<goal>unpack-dependencies</goal>
-						</goals>
-						<configuration>
-							<includeScope>compile</includeScope>
-							<outputDirectory>${project.build.outputDirectory}</outputDirectory>
-							<excludes>**/MANIFEST.MF</excludes>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
+				<version>1.4.0</version>
 				<extensions>true</extensions>
-				<executions>
-					<execution>
-						<id>bundle-manifest</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>manifest</goal>
-						</goals>
-						<configuration>
-							<excludeDependencies>true</excludeDependencies>
-							<instructions>
-								<Import-Package>javax.script,javax.swing.text.html,sun.misc</Import-Package>
-								<Export-Package>com.xafero.dynkt</Export-Package>
-							</instructions>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-jar</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<configuration>
-							<useDefaultManifestFile>true</useDefaultManifestFile>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<unpackBundle>true</unpackBundle>
+					<excludeDependencies>true</excludeDependencies>
+					<instructions>
+						<Import-Package>
+							apple.awt;resolution:=optional,
+							org.imgscalr;resolution:=optional,
+							org.objectweb.asm;resolution:=optional,
+							!org.junit,
+							*
+						</Import-Package>
+						<Export-Package>com.xafero.dynkt</Export-Package>
+						<DynamicImport-Package>*</DynamicImport-Package>
+						<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+						<Embed-Transitive>true</Embed-Transitive>
+						<Service-Component>OSGI-INF/serviceComponents.xml</Service-Component>
+					</instructions>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/dynkt-osgi/src/main/resources/OSGi-INF/serviceComponents.xml
+++ b/dynkt-osgi/src/main/resources/OSGi-INF/serviceComponents.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="KotlinScriptEngineFactory">
+    <implementation class="com.xafero.dynkt.KotlinScriptEngineFactory"/>
+    <property name="service.description" value="Kotlin ScriptEngineFactory Implementation (JSR-223)"/>
+    <property name="service.vendor" value="com.xafero"/>
+    <service>
+        <provide interface="javax.script.ScriptEngineFactory"/>
+    </service>
+</component>


### PR DESCRIPTION
These are the changes I made to let the maven-bundle-plugin create the OSGi bundle.

Notice that you should not tell the maven plugin what to import, it will figure that out automatically.

I just made some imports optional because the kotlin code imports far too many things that are dependent on a specific OS and JVM but probably refers to code that will only run if the actual OS/JVM is being used... so I think it's a safe bet to make those packages optional.
